### PR TITLE
hide activity dropdown from dashboard header: mobile

### DIFF
--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -13,6 +13,47 @@
     /* Outer shadow with green tint */ 0px 30px 60px -30px rgba(0, 0, 0, 0.3);
 }
 
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 50px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.activity-dropdown {
+  border: none;
+  outline: none;
+  border-radius: 7px;
+  font-size: 15px;
+  height: 2.5rem;
+  background-color: var(--light);
+  padding: 0px 20px;
+}
+
+.aside-tasklist,
+header {
+  position: relative;
+}
+
+.li {
+  padding: 10px 0px;
+}
+
+.li:hover {
+  background-color: var(--dark);
+  border-radius: 7px;
+  transform: scale(1.1);
+  cursor: pointer;
+}
+
+.user-menu {
+  right: 0;
+  position: absolute;
+  z-index: 1;
+  background-color: var(--darkgreen);
+}
+
 /* PC */
 @media (min-width: 1200px) {
   .dashboard-main {
@@ -77,47 +118,11 @@
   }
 
   .activity-dropdown {
+    display: none;
     min-width: 100%;
   }
-}
 
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  padding: 5px 50px;
-  align-items: center;
-  margin-top: 10px;
-}
-
-.activity-dropdown {
-  border: none;
-  outline: none;
-  border-radius: 7px;
-  font-size: 15px;
-  height: 2.5rem;
-  background-color: var(--light);
-  padding: 0px 20px;
-}
-
-.aside-tasklist,
-header {
-  position: relative;
-}
-
-.li {
-  padding: 10px 0px;
-}
-
-.li:hover {
-  background-color: var(--dark);
-  border-radius: 7px;
-  transform: scale(1.1);
-  cursor: pointer;
-}
-
-.user-menu {
-  right: 0;
-  position: absolute;
-  z-index: 1;
-  background-color: var(--darkgreen);
+  .dashboard-header {
+    padding: 0;
+  }
 }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -173,6 +173,7 @@ function Dashboard() {
             handleRemoveTask={handleRemoveTask}
             handleTaskChange={handleTaskChange}
             handleTaskCompletion={handleTaskCompletion}
+            handleSelection={handleSelection}
             task={task}
             tasks={tasks}
           />

--- a/src/components/Todo.jsx
+++ b/src/components/Todo.jsx
@@ -16,6 +16,7 @@ function Todo({
   handleRemoveTask,
   handleTaskChange,
   handleTaskCompletion,
+  handleSelection,
   task,
   tasks,
 }) {
@@ -76,6 +77,9 @@ function Todo({
         {tasks.map((task) => (
           <ListItem
             key={task.activity_id}
+            onClick={() =>
+              handleSelection({ target: { value: task.activity_id } })
+            }
             sx={{
               textDecoration: task.completed ? "line-through" : "",
               color: styles.light,

--- a/src/components/Warning.jsx
+++ b/src/components/Warning.jsx
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+import { styleContext } from "../App";
+
+function Warning({ children }) {
+  const styles = useContext(styleContext);
+  return (
+    <div
+      style={{
+        color: styles.light,
+        fontSize: styles.subfont,
+        textAlign: "center",
+        padding: "8px 0px",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+export default Warning;


### PR DESCRIPTION
Removed task dropdown from dashboard header.
Streaks now display on clicking a task item, improving usability and reducing UI clutter.